### PR TITLE
fixed ordering of dropout layers

### DIFF
--- a/tests/uanets/models/test_mc_dropout.py
+++ b/tests/uanets/models/test_mc_dropout.py
@@ -73,19 +73,16 @@ def test_dropout_network_build_seems_correct(
     # check the number of layers is correct and they are properly constructed
     assert len(model.layers) == 2
     assert len(model.layers[0].layers) == num_hidden_layers * 2
-    assert len(model.layers[1].layers) == 2
+    assert len(model.layers[1].layers) == 1
 
     for i, layer in enumerate(model.layers[0].layers):
-        if i % 2 == 0:
-            isinstance(layer, tf.keras.layers.Dropout)
+        if i % 2 == 1:
+            assert isinstance(layer, tf.keras.layers.Dropout)
             layer.rate == rate_all_layers[int(i / 2)]
-        elif i % 2 == 1:
-            isinstance(layer, tf.keras.layers.Dense)
+        elif i % 2 == 0:
+            assert isinstance(layer, tf.keras.layers.Dense)
             assert layer.units == units
             assert layer.activation == activation or layer.activation.__name__ == activation
-
-    assert isinstance(model.layers[1].layers[0], tf.keras.layers.Dropout)
-    assert model.layers[1].layers[0].rate == rate_all_layers[-1]
 
     assert isinstance(model.layers[1].layers[-1], tf.keras.layers.Dense)
     assert model.layers[1].layers[-1].units == int(np.prod(outputs.shape[1:]))

--- a/uanets/models/mc_dropout.py
+++ b/uanets/models/mc_dropout.py
@@ -82,19 +82,16 @@ class MonteCarloDropout(tf.keras.Model):
         hidden_layers = tf.keras.Sequential(name="hidden_layers")
         for hidden_layer_args in self._hidden_layer_args:
             hidden_layers.add(
-                tf.keras.layers.Dropout(rate=self.rate, dtype=self.input_tensor_spec.dtype)
+                tf.keras.layers.Dense(dtype=self.input_tensor_spec.dtype, **hidden_layer_args)
             )
             hidden_layers.add(
-                tf.keras.layers.Dense(dtype=self.input_tensor_spec.dtype, **hidden_layer_args)
+                tf.keras.layers.Dropout(rate=self.rate, dtype=self.input_tensor_spec.dtype)
             )
         return hidden_layers
 
     def _gen_output_layer(self) -> tf.keras.Model:
 
         output_layer = tf.keras.Sequential(name="output_layer")
-        output_layer.add(
-            tf.keras.layers.Dropout(rate=self.rate, dtype=self.input_tensor_spec.dtype)
-        )
         output_layer.add(
             tf.keras.layers.Dense(
                 units=self.flattened_output_shape, dtype=self.input_tensor_spec.dtype


### PR DESCRIPTION
dropout should be applied after the activation function, on the output - in the original code there was a dropout on inputs as well, simple correction - seems to eliminate weird training loss spikes that could be seen in integration test test_predictions.py 